### PR TITLE
Fix/set sensitive

### DIFF
--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -35,34 +35,37 @@ jobs:
     - uses: actions/checkout@v2
       with:
         clean: false #this is to avoid permissions on self-hosted runner
-    - name: Create Credential File
-      run: |
-        echo "$GCP_CREDENTIAL_JSON" | base64 -d > /tmp/credentials.json
-      env:
-        GCP_CREDENTIAL_JSON: ${{ secrets.GCP_CREDENTIAL_JSON}}
-    - name: Create HELM Secrets File
-      run: |
-        echo "$HELM_SECRETS" | base64 -d > /tmp/helm_secrets.yaml
-      env:
-        HELM_SECRETS: ${{ secrets.HELM_SECRETS}}
     - name: Remove Kitchen File
       run: rm -rf .kitchen
     - name: Remove Terraform Folder
       run: rm -rf examples/sample-jhub/.terraform
     - name: Remove Terraform File
       run: rm -rf examples/sample-jhub/terraform.tfstate.d
+    - name: Create Credential File
+      run: |
+        echo "$GCP_CREDENTIAL_JSON" | base64 -d > /tmp/credentials.json
+      env:
+        GCP_CREDENTIAL_JSON: ${{ secrets.GCP_CREDENTIAL_JSON}}
+    - name: Create TLS Files
+      run: |
+        echo "$JUPYTERHUB_TLS_CER" > /tmp/tls.cer
+        echo "$JUPYTERHUB_TLS_KEY" > /tmp/tls.key
+      env:
+        JUPYTERHUB_TLS_CER: ${{ secrets.JUPYTERHUB_TLS_CER}}
+        JUPYTERHUB_TLS_KEY: ${{ secrets.JUPYTERHUB_TLS_KEY}}
     - name: Authorize service account
       run: gcloud auth activate-service-account ${{ secrets.GCP_PF_SA }} --key-file=/tmp/credentials.json
     - name: Run Kitchen
       run: kitchen test
       env:
-        TF_VAR_billing_account: ${{ secrets.GCP_BILLING_ACCOUNT }}
+        TF_VAR_billing_account: ${{ secrets.GCP_BURWOOD_BILLING_ACCOUNT }}
         TF_VAR_org_id: ${{ secrets.GCP_ORG_ID }}
         TF_VAR_folder_id: ${{ secrets.GCP_CCV_CI_FOLDER_ID }}
         TF_VAR_infoblox_username: ${{ secrets.INFOBLOX_JHUB_USER }}
         TF_VAR_infoblox_password: ${{ secrets.INFOBLOX_JHUB_PSWD }}
         TF_VAR_infoblox_host: ${{secrets.INFOBLOX_JHUB_HOST}}
-        TF_VAR_helm_secrets_file: /tmp/helm_secrets.yaml
+        TF_VAR_site_certificate_file: /tmp/tls.cer
+        TF_VAR_site_certificate_key_file: /tmp/tls.key
         GOOGLE_APPLICATION_CREDENTIALS: /tmp/credentials.json
 
       

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -51,14 +51,14 @@ jobs:
         echo "$JUPYTERHUB_TLS_CER" > /tmp/tls.cer
         echo "$JUPYTERHUB_TLS_KEY" > /tmp/tls.key
       env:
-        JUPYTERHUB_TLS_CER: ${{ secrets.JUPYTERHUB_TLS_CER}}
-        JUPYTERHUB_TLS_KEY: ${{ secrets.JUPYTERHUB_TLS_KEY}}
+        JUPYTERHUB_TLS_CER: ${{ secrets.JUPYTERHUB_TLS_CER }}
+        JUPYTERHUB_TLS_KEY: ${{ secrets.JUPYTERHUB_TLS_KEY }}
     - name: Authorize service account
       run: gcloud auth activate-service-account ${{ secrets.GCP_PF_SA }} --key-file=/tmp/credentials.json
     - name: Run Kitchen
       run: kitchen test
       env:
-        TF_VAR_billing_account: ${{ secrets.GCP_BURWOOD_BILLING_ACCOUNT }}
+        TF_VAR_billing_account: ${{ secrets.GCP_BILLING_ACCOUNT }}
         TF_VAR_org_id: ${{ secrets.GCP_ORG_ID }}
         TF_VAR_folder_id: ${{ secrets.GCP_CCV_CI_FOLDER_ID }}
         TF_VAR_infoblox_username: ${{ secrets.INFOBLOX_JHUB_USER }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | terraform | >= 0.12 |
 | google | >= 3.0 |
 | google-beta | >= 3.0 |
-| helm | ~> 1.0 |
+| helm | ~> 1.1 |
 | kubernetes | >= 1.4.0 |
 
 ## Providers
@@ -50,6 +50,8 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | activate\_apis | The list of apis to activate within the project | `list(string)` | `[]` | no |
+| auth\_secretkeyvaluemap | Key Value Map for secret variables used by the authenticator | `map` | <pre>{<br>  "auth.dummy.password": "123"<br>}</pre> | no |
+| auth\_type | Type OAuth e.g google | `string` | `"dummy"` | no |
 | auto\_create\_network | Auto create default network. | `bool` | `false` | no |
 | automount\_service\_account\_token | Enable automatin mounting of the service account token | `bool` | `true` | no |
 | billing\_account | Billing account id. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | core\_pool\_oauth\_scope | OAuth scope for core-component pool | `string` | `"https://www.googleapis.com/auth/cloud-platform"` | no |
 | core\_pool\_preemptible | Make core-component pool preemptible | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `false` | no |
+| create\_tls\_secret | If set to true, user will be passing tls key and certificate to create a kubernetes secret, and use it in their helm chart | `bool` | `true` | no |
 | default\_service\_account | Project default service account setting: can be one of delete, depriviledge, or keep. | `string` | `"delete"` | no |
 | description | VPC description | `string` | `"Deployed through Terraform."` | no |
 | disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. | `string` | `"true"` | no |
@@ -76,7 +77,6 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | gcp\_zone | The GCP zone to deploy the runner into. | `string` | `"us-east1-b"` | no |
 | helm\_deploy\_timeout | Time for helm to wait for deployment of chart and downloading of docker image | `number` | `1000` | no |
 | helm\_repository\_url | URL for JupyterHub's Helm chart | `string` | `"https://jupyterhub.github.io/helm-chart/"` | no |
-| helm\_secrets\_file | Relative path and file name. Example: secrets.yaml | `string` | n/a | yes |
 | helm\_values\_file | Relative path and file name. Example: values.yaml | `string` | n/a | yes |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `false` | no |
@@ -111,12 +111,15 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | scale\_up\_command | Command for scale-up cron job | `list(string)` | <pre>[<br>  "kubectl",<br>  "scale",<br>  "--replicas=3",<br>  "statefulset/user-placeholder"<br>]</pre> | no |
 | scale\_up\_name | Name of scale-up cron job | `string` | `"scale-up"` | no |
 | scale\_up\_schedule | Schedule for scale-up cron job | `string` | `"1 6 * * 1-5"` | no |
+| site\_certificate | File containing the TLS certificate | `string` | n/a | yes |
+| site\_certificate\_key | File containing the TLS certificate key | `string` | n/a | yes |
 | skip\_provisioners | Flag to skip local-exec provisioners | `bool` | `false` | no |
 | subnet\_flow\_logs | Whether the subnet will record and send flow log data to logging | `string` | `"true"` | no |
 | subnet\_ip | Subnet IP CIDR. | `string` | `"10.0.0.0/17"` | no |
 | subnet\_name | Name of the subnet. | `string` | `"kubernetes-subnet"` | no |
 | subnet\_private\_access | Whether this subnet will have private Google access enabled | `string` | `"true"` | no |
 | subnetwork | The subnetwork to host the cluster in | `string` | `"kubernetes-subnet"` | no |
+| tls\_secret\_name | TLS secret name used in secret creation, it must match with what is used by user in helm chart | `string` | `"jupyterhub-tls"` | no |
 | user\_pool\_auto\_repair | Enable auto-repair of user pool | `bool` | `true` | no |
 | user\_pool\_auto\_upgrade | Enable auto-upgrade of user pool | `bool` | `true` | no |
 | user\_pool\_disk\_size\_gb | Size of disk for user pool | `number` | `100` | no |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | activate\_apis | The list of apis to activate within the project | `list(string)` | `[]` | no |
-| auth\_secretkeyvaluemap | Key Value Map for secret variables used by the authenticator | `map` | <pre>{<br>  "auth.dummy.password": "123"<br>}</pre> | no |
+| auth\_secretkeyvaluemap | Key Value Map for secret variables used by the authenticator | `map(string)` | <pre>{<br>  "auth.dummy.password": "dummy_password"<br>}</pre> | no |
 | auth\_type | Type OAuth e.g google | `string` | `"dummy"` | no |
 | auto\_create\_network | Auto create default network. | `bool` | `false` | no |
 | automount\_service\_account\_token | Enable automatin mounting of the service account token | `bool` | `true` | no |

--- a/examples/sample-jhub/main.tf
+++ b/examples/sample-jhub/main.tf
@@ -61,10 +61,14 @@ module "sample-jhub" {
   user_pool_initial_node_count = 1
 
   # ---------------- HELM/JHUB VARIABLES -----------------------
+
+  site_certificate = file("./secrets/tls.cer")
+  site_certificate_key = file("./secrets/tls.key")
+
+  # ---------------- HELM/JHUB VARIABLES -----------------------
   jhub_helm_version   = "0.9.0"
   helm_deploy_timeout = 1000
   helm_values_file    = "./values.yaml"
-  helm_secrets_file   = var.helm_secrets_file
 
   # ---------------- CRONJOB VARIABLES -----------------------
   scale_up_schedule   = "30 19 * * 4"

--- a/examples/sample-jhub/main.tf
+++ b/examples/sample-jhub/main.tf
@@ -61,8 +61,8 @@ module "sample-jhub" {
   user_pool_initial_node_count = 1
 
   # ---------------- HELM/JHUB VARIABLES -----------------------
-
-  site_certificate = file(var.site_certificate_file)
+  create_tls_secret    = true
+  site_certificate     = file(var.site_certificate_file)
   site_certificate_key = file(var.site_certificate_key_file)
 
   # ---------------- HELM/JHUB VARIABLES -----------------------

--- a/examples/sample-jhub/main.tf
+++ b/examples/sample-jhub/main.tf
@@ -62,8 +62,8 @@ module "sample-jhub" {
 
   # ---------------- HELM/JHUB VARIABLES -----------------------
 
-  site_certificate = file("./secrets/tls.cer")
-  site_certificate_key = file("./secrets/tls.key")
+  site_certificate = file(var.site_certificate_file)
+  site_certificate_key = file(var.site_certificate_key_file)
 
   # ---------------- HELM/JHUB VARIABLES -----------------------
   jhub_helm_version   = "0.9.0"

--- a/examples/sample-jhub/values.yaml
+++ b/examples/sample-jhub/values.yaml
@@ -30,6 +30,13 @@ singleuser:
         command: ["/bin/sh", "-c", "chmod -f 600 /home/jovyan/.ssh/id_rsa || true;"]
 proxy:
   https:
+    enabled: true
     type: secret
     secret:
-        name: jupyterhub-tls
+      name: jupyterhub-tls
+      key: tls.key
+      crt: tls.crt
+
+# proxy:
+#   https:
+#     enabled: true

--- a/examples/sample-jhub/values.yaml
+++ b/examples/sample-jhub/values.yaml
@@ -28,3 +28,8 @@ singleuser:
     postStart:
       exec:
         command: ["/bin/sh", "-c", "chmod -f 600 /home/jovyan/.ssh/id_rsa || true;"]
+proxy:
+  https:
+    type: secret
+    secret:
+        name: jupyterhub-tls

--- a/examples/sample-jhub/variables.tf
+++ b/examples/sample-jhub/variables.tf
@@ -15,3 +15,11 @@ variable "infoblox_password" {
 
 variable "infoblox_host" {
 }
+
+variable "site_certificate_file" {
+    default = "./secrets/tls.cer"
+}
+
+variable "site_certificate_key_file"{
+    default = "./secrets/tls.key"
+}

--- a/examples/sample-jhub/variables.tf
+++ b/examples/sample-jhub/variables.tf
@@ -15,7 +15,3 @@ variable "infoblox_password" {
 
 variable "infoblox_host" {
 }
-
-variable "helm_secrets_file" {
-  default = "./secrets.yaml"
-}

--- a/examples/sample-jhub/variables.tf
+++ b/examples/sample-jhub/variables.tf
@@ -17,9 +17,9 @@ variable "infoblox_host" {
 }
 
 variable "site_certificate_file" {
-    default = "./secrets/tls.cer"
+  default = "./secrets/tls.cer"
 }
 
-variable "site_certificate_key_file"{
-    default = "./secrets/tls.key"
+variable "site_certificate_key_file" {
+  default = "./secrets/tls.key"
 }

--- a/main.tf
+++ b/main.tf
@@ -170,9 +170,9 @@ module "jhub_helm" {
   scale_up_name                   = var.scale_up_name
   scale_up_schedule               = var.scale_up_schedule
   scale_up_command                = var.scale_up_command
-  create_tls_secret = var.create_tls_secret
-  tls_secret_name = var.tls_secret_name
-  site_certificate = var.site_certificate
-  site_certificate_key = var.site_certificate_key
+  create_tls_secret               = var.create_tls_secret
+  tls_secret_name                 = var.tls_secret_name
+  site_certificate                = var.site_certificate
+  site_certificate_key            = var.site_certificate_key
 
 }

--- a/main.tf
+++ b/main.tf
@@ -174,5 +174,6 @@ module "jhub_helm" {
   tls_secret_name                 = var.tls_secret_name
   site_certificate                = var.site_certificate
   site_certificate_key            = var.site_certificate_key
-
+  auth_type                       = var.auth_type
+  auth_secretkeyvaluemap          = var.auth_secretkeyvaluemap
 }

--- a/main.tf
+++ b/main.tf
@@ -141,36 +141,13 @@ resource "null_resource" "cluster_credentials" {
 }
 
 
-
-# ------------------------------------------------------------
-#  TLS (if needed)
-# ------------------------------------------------------------
-resource "kubernetes_secret" "tls_secret" {
-  count = var.create_tls_secret ? 1 : 0
-
-  type  = "kubernetes.io/tls"
-
-  metadata {
-    name      = var.tls_secret_name
-    namespace = "jhub"
-  }
-
-  data = {
-    "tls.crt" = "${var.site_certificate}"
-    "tls.key" = "${var.site_certificate_key}"
-  }
-
-  depends_on = [null_resource.cluster_credentials]
-
-}
-
 # define after local-exec to create a dependency for the next module
 data "null_data_source" "context" {
   inputs = {
     location = var.regional ? var.region : var.gcp_zone
   }
 
-  depends_on = [kubernetes_secret.tls_secret]
+  depends_on = [null_resource.cluster_credentials]
 }
 
 # ------------------------------------------------------------
@@ -193,5 +170,9 @@ module "jhub_helm" {
   scale_up_name                   = var.scale_up_name
   scale_up_schedule               = var.scale_up_schedule
   scale_up_command                = var.scale_up_command
+  create_tls_secret = var.create_tls_secret
+  tls_secret_name = var.tls_secret_name
+  site_certificate = var.site_certificate
+  site_certificate_key = var.site_certificate_key
 
 }

--- a/modules/helm-jhub/main.tf
+++ b/modules/helm-jhub/main.tf
@@ -51,6 +51,10 @@ resource "kubernetes_secret" "tls_secret" {
   depends_on = [kubernetes_namespace.jhub]
 }
 
+locals {
+  helm_release_wait_condition = var.create_tls_secret ? kubernetes_secret.tls_secret[0].metadata[0].name : kubernetes_namespace.jhub.metadata[0].name
+}
+
 resource "helm_release" "jhub" {
 
   name       = "jhub"
@@ -94,8 +98,7 @@ resource "helm_release" "jhub" {
     }
   }
 
-  #TO DO: if not using secret TLS this won't work
-  depends_on = [kubernetes_secret.tls_secret]
+  depends_on = [local.helm_release_wait_condition]
 }
 
 # ------------------------------------------------------------

--- a/modules/helm-jhub/main.tf
+++ b/modules/helm-jhub/main.tf
@@ -79,6 +79,21 @@ resource "helm_release" "jhub" {
     value = "{${var.jhub_url}}"
   }
 
+  #Authentication
+  set {
+    name  = "auth.type"
+    value = var.auth_type
+  }
+
+  #Authentication secrets
+  dynamic "set_sensitive" {
+    for_each = var.auth_secretkeyvaluemap
+    content {
+      name  = set_sensitive.key
+      value = set_sensitive.value
+    }
+  }
+
   #TO DO: if not using secret TLS this won't work
   depends_on = [kubernetes_secret.tls_secret]
 }

--- a/modules/helm-jhub/main.tf
+++ b/modules/helm-jhub/main.tf
@@ -36,7 +36,7 @@ resource "random_id" "jhub_proxy_token" {
 resource "kubernetes_secret" "tls_secret" {
   count = var.create_tls_secret ? 1 : 0
 
-  type  = "kubernetes.io/tls"
+  type = "kubernetes.io/tls"
 
   metadata {
     name      = var.tls_secret_name

--- a/modules/helm-jhub/main.tf
+++ b/modules/helm-jhub/main.tf
@@ -40,7 +40,6 @@ resource "helm_release" "jhub" {
   timeout    = var.helm_deploy_timeout
 
   values = [
-    "${file(var.helm_secrets_file)}",
     "${file(var.helm_values_file)}"
   ]
 

--- a/modules/helm-jhub/main.tf
+++ b/modules/helm-jhub/main.tf
@@ -30,6 +30,27 @@ resource "random_id" "jhub_proxy_token" {
   byte_length = 32
 }
 
+# ------------------------------------------------------------
+#  TLS (if needed)
+# ------------------------------------------------------------
+resource "kubernetes_secret" "tls_secret" {
+  count = var.create_tls_secret ? 1 : 0
+
+  type  = "kubernetes.io/tls"
+
+  metadata {
+    name      = var.tls_secret_name
+    namespace = var.jhub_namespace
+  }
+
+  data = {
+    "tls.crt" = "${var.site_certificate}"
+    "tls.key" = "${var.site_certificate_key}"
+  }
+
+  depends_on = [kubernetes_namespace.jhub]
+}
+
 resource "helm_release" "jhub" {
 
   name       = "jhub"
@@ -58,7 +79,8 @@ resource "helm_release" "jhub" {
     value = "{${var.jhub_url}}"
   }
 
-  depends_on = [kubernetes_namespace.jhub]
+  #TO DO: if not using secret TLS this won't work
+  depends_on = [kubernetes_secret.tls_secret]
 }
 
 # ------------------------------------------------------------

--- a/modules/helm-jhub/variables.tf
+++ b/modules/helm-jhub/variables.tf
@@ -1,4 +1,29 @@
 # ---------------------------------------------------------------
+#  TLS VARIABLES
+# ---------------------------------------------------------------
+variable "create_tls_secret" {
+  description = "If set to true, user will be passing tls key and certificate to create a kubernetes secret, and use it in their helm chart"
+  type        = bool
+  default     = true
+}
+
+variable "tls_secret_name" {
+  description = "TLS secret name used in secret creation, it must match with what is used by user in helm chart"
+  type        = string
+  default     = "jupyterhub-tls"
+}
+
+variable "site_certificate" {
+  type        = string
+  description = "File containing the TLS certificate"
+}
+
+variable "site_certificate_key" {
+  type        = string
+  description = "File containing the TLS certificate key"
+}
+
+# ---------------------------------------------------------------
 #  HELM VARIABLES
 # ---------------------------------------------------------------
 variable "kubernetes_context" {

--- a/modules/helm-jhub/variables.tf
+++ b/modules/helm-jhub/variables.tf
@@ -89,10 +89,10 @@ variable "auth_type" {
 }
 
 variable "auth_secretkeyvaluemap" {
-  type        = map
+  type        = map(string)
   description = "Key Value Map for secret variables used by the authenticator"
   default = {
-    "auth.dummy.password" = "123"
+    "auth.dummy.password" = "dummy_password"
   }
 }
 

--- a/modules/helm-jhub/variables.tf
+++ b/modules/helm-jhub/variables.tf
@@ -82,6 +82,20 @@ variable "jhub_url" {
   description = "URL for the jupyter hub"
 }
 
+variable "auth_type" {
+  type        = string
+  description = "Type OAuth e.g google"
+  default     = "dummy"
+}
+
+variable "auth_secretkeyvaluemap" {
+  type        = map
+  description = "Key Value Map for secret variables used by the authenticator"
+  default = {
+    "auth.dummy.password" = "123"
+  }
+}
+
 # --------------------------------------
 #   Cron Jobs
 # --------------------------------------

--- a/modules/helm-jhub/variables.tf
+++ b/modules/helm-jhub/variables.tf
@@ -34,10 +34,6 @@ variable "helm_values_file" {
   description = "YAML file containing JupyterHub HELM values. Relative path and file name. Example: config.yaml"
 }
 
-variable "helm_secrets_file" {
-  type        = string
-  description = "YAML file containing JupyterHub HELM secret values. Relative path and file name. Example: config.yaml"
-}
 
 variable "jhub_helm_version" {
   type        = string

--- a/test/integration/sample-jhub/controls/sample-jhub.rb
+++ b/test/integration/sample-jhub/controls/sample-jhub.rb
@@ -3,7 +3,7 @@ title "Test basic availability of JupyterHub"
 
 jhub_url = attribute("jhub_url")
 
-describe http("#{jhub_url}/hub/login", ssl_verify: false) do
+describe http("#{jhub_url}/hub/login", ssl_verify: true) do
     its('status') { should cmp 200 }
     its('headers.Content-Type') { should cmp 'text/html' }
 end

--- a/test/integration/sample-jhub/controls/sample-jhub.rb
+++ b/test/integration/sample-jhub/controls/sample-jhub.rb
@@ -3,7 +3,7 @@ title "Test basic availability of JupyterHub"
 
 jhub_url = attribute("jhub_url")
 
-describe http("#{jhub_url}/hub/login", ssl_verify: true) do
+describe http("#{jhub_url}/hub/login", ssl_verify: false) do
     its('status') { should cmp 200 }
     its('headers.Content-Type') { should cmp 'text/html' }
 end

--- a/variables.tf
+++ b/variables.tf
@@ -393,6 +393,32 @@ variable "user_pool_oauth_scope" {
   default     = "https://www.googleapis.com/auth/cloud-platform"
 }
 
+
+# ---------------------------------------------------------------
+#  TLS VARIABLES
+# ---------------------------------------------------------------
+variable "create_tls_secret" {
+  description = "If set to true, user will be passing tls key and certificate to create a kubernetes secret, and use it in their helm chart"
+  type        = bool
+  default     = true
+}
+
+variable "tls_secret_name" {
+  description = "TLS secret name used in secret creation, it must match with what is used by user in helm chart"
+  type        = string
+  default     = "jupyterhub-tls"
+}
+
+variable "site_certificate" {
+  type        = string
+  description = "File containing the TLS certificate"
+}
+
+variable "site_certificate_key" {
+  type        = string
+  description = "File containing the TLS certificate key"
+}
+
 # ---------------------------------------------------------------
 #  HELM VARIABLES
 # ---------------------------------------------------------------
@@ -412,11 +438,6 @@ variable "helm_repository_url" {
 variable "helm_values_file" {
   type        = string
   description = "Relative path and file name. Example: values.yaml"
-}
-
-variable "helm_secrets_file" {
-  type        = string
-  description = "Relative path and file name. Example: secrets.yaml"
 }
 
 variable "jhub_helm_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,34 @@ variable range_name_services {
   default     = "kubernetes-services"
 }
 
+# --------------------------------------
+#   Infoblox
+# --------------------------------------
+variable "infoblox_username" {
+  description = "Username to authenticate with Infoblox server"
+  type        = string
+}
+
+variable "infoblox_password" {
+  description = "Password to authenticate with Infoblox server"
+  type        = string
+}
+
+variable "infoblox_host" {
+  description = "Infoblox host"
+  type        = string
+}
+
+variable "record_domain" {
+  description = "The domain on the record. hostaname.domain = FQDN"
+  type        = string
+}
+
+variable "record_hostname" {
+  description = "The domain on the record. hostaname.domain = FQDN"
+  type        = string
+}
+
 # ---------------------------------------------------------------
 #  GKE VARIABLES
 # ---------------------------------------------------------------
@@ -451,30 +479,18 @@ variable "helm_deploy_timeout" {
   default     = 1000
 }
 
-# INFOBLOX
-variable "infoblox_username" {
-  description = "Username to authenticate with Infoblox server"
+variable "auth_type" {
   type        = string
+  description = "Type OAuth e.g google"
+  default     = "dummy"
 }
 
-variable "infoblox_password" {
-  description = "Password to authenticate with Infoblox server"
-  type        = string
-}
-
-variable "infoblox_host" {
-  description = "Infoblox host"
-  type        = string
-}
-
-variable "record_domain" {
-  description = "The domain on the record. hostaname.domain = FQDN"
-  type        = string
-}
-
-variable "record_hostname" {
-  description = "The domain on the record. hostaname.domain = FQDN"
-  type        = string
+variable "auth_secretkeyvaluemap" {
+  type        = map
+  description = "Key Value Map for secret variables used by the authenticator"
+  default = {
+    "auth.dummy.password" = "123"
+  }
 }
 
 # --------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -486,10 +486,10 @@ variable "auth_type" {
 }
 
 variable "auth_secretkeyvaluemap" {
-  type        = map
+  type        = map(string)
   description = "Key Value Map for secret variables used by the authenticator"
   default = {
-    "auth.dummy.password" = "123"
+    "auth.dummy.password" = "dummy_password"
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,6 @@ terraform {
     google      = ">= 3.0"
     google-beta = ">= 3.0"
     kubernetes  = ">= 1.4.0"
-    helm        = "~> 1.0"
+    helm        = "~> 1.1"
   }
 }


### PR DESCRIPTION
* Store TLS certs in a kubernetes secret
* Adjust example and CI to use secret
* Add OAuth with `set_sensitive` for related variables

At the moment, the `helm` resource depends on the `tls secret` to make sure it exists before deployment. However, if manual certificate is not used this will not work as the resource will have a count of 0. Any recommendations are welcomed!